### PR TITLE
Remove shell when calling spawn

### DIFF
--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -139,7 +139,6 @@ export function buildCommand(query: SearchQuery) {
   // TODO: multi-workspaces support
   return spawn(command, args, {
     cwd: uris[0],
-    shell: process.platform === 'win32', // it is safe because it is end user input
   })
 }
 


### PR DESCRIPTION
This fixes an issue where parts of the pattern are not passed when searching on Windows.